### PR TITLE
缩小查找范围

### DIFF
--- a/delete_navicat.sh
+++ b/delete_navicat.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # 定义要查找的目录
-directories=("/private" "$HOME")
+directories=("/private" "$HOME/Library")
 
 # 遍历目录
 for dir in "${directories[@]}"; do


### PR DESCRIPTION
navicat 只会在 ~/Library 下的目录创建文件，此次修改是防止使用者在 ~ 目录下存放大文件导致脚本运行时间过长