### PR TITLE
Create macos_install_launch_agent.sh

### DIFF
--- a/macos_install_launch_agent.sh
+++ b/macos_install_launch_agent.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -uo pipefail
+
+# 获取脚本所在目录的绝对路径
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESET_SCRIPT_NAME="reset_navicat.sh"
+RESET_SCRIPT_PATH="$SCRIPT_DIR/$RESET_SCRIPT_NAME"
+PLIST_NAME="com.navicat.reset.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/$PLIST_NAME"
+
+# 检查 reset_navicat.sh 是否存在
+if [[ ! -f "$RESET_SCRIPT_PATH" ]]; then
+    echo "错误: 找不到 $RESET_SCRIPT_NAME 脚本"
+    echo "请确保 $RESET_SCRIPT_NAME 与此安装脚本在同一目录下"
+    exit 1
+fi
+
+# 给 reset_navicat.sh 添加执行权限
+chmod +x "$RESET_SCRIPT_PATH"
+
+# 创建 LaunchAgents 目录（如果不存在）
+mkdir -p "$HOME/Library/LaunchAgents"
+
+# 生成 plist 文件内容
+cat > "$PLIST_DEST" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.navicat.reset</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>$RESET_SCRIPT_PATH</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StartInterval</key>
+    <integer>86400</integer>
+
+    <key>StandardOutPath</key>
+    <string>$HOME/Library/Logs/com.navicat.reset.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>$HOME/Library/Logs/com.navicat.reset.error.log</string>
+</dict>
+</plist>
+EOF
+
+echo "已创建 plist 文件: $PLIST_DEST"
+
+# 卸载旧的配置（如果存在）
+launchctl list | grep -q "com.navicat.reset" && launchctl unload "$PLIST_DEST" 2>/dev/null
+
+# 加载新的配置
+if launchctl load "$PLIST_DEST"; then
+    echo "✅ Launch Agent 已成功加载！"
+    echo ""
+    echo "配置信息："
+    echo "- 脚本路径: $RESET_SCRIPT_PATH"
+    echo "- 日志文件: $HOME/Library/Logs/com.navicat.reset.log"
+    echo "- 错误日志: $HOME/Library/Logs/com.navicat.reset.error.log"
+    echo ""
+    echo "管理命令："
+    echo "- 查看状态: launchctl list | grep navicat"
+    echo "- 手动启动: launchctl start com.navicat.reset"
+    echo "- 手动停止: launchctl stop com.navicat.reset"
+    echo "- 卸载配置: launchctl unload $PLIST_DEST"
+else
+    echo "❌ 加载 Launch Agent 失败！"
+    exit 1
+fi


### PR DESCRIPTION

MacOS 开机自启脚本，每24小时执行`reset_navicat.sh`实现自动续期。

配置说明

  1. 创建了 Launch Agent：~/Library/LaunchAgents/com.navicat.reset.plist
  2. 关键配置项：
    - RunAtLoad: 开机时自动运行
    - StartInterval: 每86400秒（24小时）运行一次
    - 日志文件：标准输出和错误分别记录到 ~/Library/Logs/

  管理命令

  - 检查状态：launchctl list | grep navicat
  - 手动启动：launchctl start com.navicat.reset
  - 手动停止：launchctl stop com.navicat.reset
  - 卸载：launchctl unload ~/Library/LaunchAgents/com.navicat.reset.plist

脚本会在每次开机时自动运行，并且每天都会自动执行一次 Navicat 重置。

