### PR TITLE
优化“自动重置脚本”，让mac里的“后台脚本”里显示脚本名称

### DIFF
--- a/auto_reset_navicat.command
+++ b/auto_reset_navicat.command
@@ -23,6 +23,8 @@ if [[ "$1" == "uninstall" ]]; then
     exit 0
 fi
 
+chmod +x $RESET_SCRIPT_PATH
+
 # 写入新的 plist 文件
 cat > "$PLIST_PATH" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -34,7 +36,6 @@ cat > "$PLIST_PATH" <<EOF
     <string>$PLIST_NAME</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
         <string>$RESET_SCRIPT_PATH</string>
     </array>
     <key>StartInterval</key>


### PR DESCRIPTION
让mac里的“后台脚本”里显示脚本名称，而不是bash，方便用户理解和管理mac的“后台脚本”
<img width="473" height="60" alt="image" src="https://github.com/user-attachments/assets/c8d55b95-160f-4d2e-b097-22020c4e0403" />
